### PR TITLE
Riemann solver corrections for 2D SWE equations

### DIFF
--- a/src/rpn2_shallow_bathymetry_fwave.f90
+++ b/src/rpn2_shallow_bathymetry_fwave.f90
@@ -40,7 +40,7 @@ subroutine rpn2(ixy, maxm, num_eqn, num_waves, num_aux, num_ghost, &
     real(kind=8) :: grav, dry_tolerance, sea_level
     common /cparam/ grav, dry_tolerance, sea_level
     
-    real(kind=8) :: hl, ul, vl, bl, hr, ur, vr, br, hbar, uhat, vhat, chat
+    real(kind=8) :: hl, ul, vl, bl, hr, ur, vr, br, hbar, uhat, chat
     real(kind=8) :: phil, phir, dry_state_l, dry_state_r
     real(kind=8) :: R(3,3)
     real(kind=8) :: fluxdiff(3), beta(3)
@@ -91,8 +91,7 @@ subroutine rpn2(ixy, maxm, num_eqn, num_waves, num_aux, num_ghost, &
     
         ! Roe average states (Roe's linearization)
         hbar = 0.5d0 * (hr + hl)
-        uhat = (sqrt(hr) * ur + sqrt(hl) * ul) / (sqrt(hr) + sqrt(hl)) 
-        ! vhat = (sqrt(hr) * vr + sqrt(hl) * vl) / (sqrt(hr) + sqrt(hl))
+        uhat = (sqrt(hr) * ur + sqrt(hl) * ul) / (sqrt(hr) + sqrt(hl))
         chat = sqrt(grav * hbar)
     
         ! Flux differences
@@ -143,10 +142,5 @@ subroutine rpn2(ixy, maxm, num_eqn, num_waves, num_aux, num_ghost, &
         enddo
 
     enddo ! End of main loop
-
-    if (.not.all(amdq == 0.d0) .or. .not.all(apdq == 0.d0)) then
-        ! print *,amdq, apdq
-        stop "Uhoh"
-    end if
 
 end subroutine rpn2

--- a/src/rpn2_shallow_bathymetry_fwave.f90
+++ b/src/rpn2_shallow_bathymetry_fwave.f90
@@ -41,149 +41,96 @@ subroutine rpn2(ixy, maxm, num_eqn, num_waves, num_aux, num_ghost, &
     common /cparam/ grav, dry_tolerance, sea_level
     
     real(kind=8) :: hl, ul, vl, bl, hr, ur, vr, br, hbar, uhat, vhat, chat
-    real(kind=8) :: phil, phir, n_1, n_2, dry_state_l, dry_state_r
+    real(kind=8) :: phil, phir, dry_state_l, dry_state_r
     real(kind=8) :: R(3,3)
     real(kind=8) :: fluxdiff(3), beta(3)
     
-    integer :: i, j, k
+    integer :: i, k, normal_index, transverse_index
     
-    ! Define normal and tangential directions of the current slice. This is needed
-    ! to use the right components of the system that correspond to the momentum in
-    ! the normal and tangential directions. Since this Riemann solver is used for
-    ! both x- and y-slices we do not use names "n" for the normal component and "t"
-    ! for the tangential component, but we simply define a vector n = (n_1,n_2)^T
-    ! whose component depends on the current slice direction.
-    !
-    ! See for instance: D. Ambrosi
-    !                    Approximation of shallow water equations by Roe's Riemann solver
-    !                    International Journal of numerical methods in fluids
-    !                    VOL. 20, 157-168 (1995)
-
-    if (ixy .eq. 1) then
-        n_1 = 1.d0  ! # This means vertical interface,
-        n_2 = 0.d0  ! # e.g. normal vector pointing in the x direction
+    ! Determine normal and tangential directions
+    if (ixy == 1) then
+        normal_index = 2
+        transverse_index = 3
     else
-        n_1 = 0.d0 ! # This means horizontal interface,
-        n_2 = 1.d0 ! # e.g. normal vector pointing in the y direction
-    endif
+        normal_index = 3
+        transverse_index = 2
+    end if
 
-    !Now, it is possible to loop over the cells in this slice
-    do i=2-num_ghost,num_cells+num_ghost
-        dry_state_l = merge(1.d0, 0.d0, qr(1, i - 1) < dry_tolerance)
-        dry_state_r = merge(1.d0, 0.d0, ql(1, i) < dry_tolerance)
+    amdq = 0.d0
+    apdq = 0.d0
+
+    ! Primary loop over each cell
+    do i = 2 - num_ghost, num_cells + num_ghost
+        
+        ! Check for dry states - need merge here to convert to float
+        dry_state_l = merge(0.d0, 1.d0, qr(1, i - 1) < dry_tolerance)
+        dry_state_r = merge(0.d0, 1.d0, ql(1, i) < dry_tolerance)
+
+        if (qr(1, i - 1) < dry_tolerance .or. ql(1, i) < dry_tolerance) then
+            stop "Cannot handle dry-states quite yet!"
+        end if
 
         ! Note that for the states below u is always the normal velocity and
         ! v is always the tangential velocity
 
-        ! # Left states
-        hl = qr(1, i - 1)
-        ul = ((qr(2, i - 1) / hl) * n_1 + (qr(3, i - 1) / hl) * n_2) * dry_state_l
-        vl = ((qr(2, i - 1) / hl) * n_2 + (qr(3, i - 1) / hl) * n_1) * dry_state_l
+        ! Left states
+        hl = qr(1, i - 1) * dry_state_l
+        ul = qr(normal_index, i - 1) / qr(1, i - 1) * dry_state_l
+        vl = qr(transverse_index, i - 1) / qr(1, i - 1) * dry_state_l
         phil = (0.5d0 * grav * hl**2 + hl * ul**2) * dry_state_l
 
-        bl = auxr(1,i-1)
+        bl = auxr(1, i - 1)
     
-        ! # Right states
-        hr = ql(1, i)
-        ur = ((ql(2, i) / hr) * n_1 + (ql(3, i) / hr) * n_2) * dry_state_r
-        vr = ((ql(2, i) / hr) * n_2 + (ql(3, i) / hr) * n_1) * dry_state_r
+        ! Right states
+        hr = ql(1, i) * dry_state_r
+        ur = ql(normal_index, i) / ql(1, i) * dry_state_r
+        vr = ql(transverse_index, i) / ql(1, i) * dry_state_r
         phir = (0.5d0 * grav * hr**2 + hr * ur**2) * dry_state_r
 
         br = auxl(1, i)
     
-        ! # Roe average states (Roe's linearization)
+        ! Roe average states (Roe's linearization)
         hbar = 0.5d0 * (hr + hl)
         uhat = (sqrt(hr) * ur + sqrt(hl) * ul) / (sqrt(hr) + sqrt(hl)) 
-        vhat = (sqrt(hr) * vr + sqrt(hl) * vl) / (sqrt(hr) + sqrt(hl))
+        ! vhat = (sqrt(hr) * vr + sqrt(hl) * vl) / (sqrt(hr) + sqrt(hl))
         chat = sqrt(grav * hbar)
     
-        ! # Flux differences
-        ! ##################
-        ! # In order to compute these differences in an efficient way (avoid if statements)
-        ! # we compute the scalar product between the velocity vector at the interface and the
-        ! # normal vector "{n} = {n_1,n_2}^T" which has been defined above.
-        ! fluxdiff(1) = hr*(ur*n_1 + vr*n_2) - hl*(ul*n_1 + vl*n_2) ! Easy to understand
+        ! Flux differences
         fluxdiff(1) = hr * ur - hl * ul
-
-        fluxdiff(2) = phir - phil + grav * hbar * (br - bl) ! Always normal
-
-        fluxdiff(3) = hr * ur * vr - hl * ul * vl ! Always tangential
+        fluxdiff(2) = phir - phil + grav * hbar * (br - bl)
+        fluxdiff(3) = hr * ur * vr - hl * ul * vl
     
-        ! # If the slice is in the y-direction we have:
-        ! # fluxdiff(2) = (hr*ur^2 + 1/2*grav*hr^2) - (hl*ul^2 + 1/2*grav*hl^2)
-        ! # fluxdiff(3) = (hr*ur*vr) - (hl*ul*vl)
-        ! #
-        ! # If the slice is in the x-direction we have:
-        ! # fluxdiff(2) = (hr*ur*vr) - (hl*ul*vl)
-        ! # fluxdiff(3) = (hr*vr^2 + 1/2*grav*hr^2) - (hl*vl^2 + 1/2*grav*hl^2)
-        ! #
-        ! # Using the vector component n_1 and n_2 defined above,
-        ! # this two possibilities can be achieved in the following way:
-        ! fluxdiff(2) = (hr*ur*(ur*n_1 + vr*n_2)+0.5*grav*hr*hr*n_1)-(hl*ul*(ul*n_1 + vl*n_2)+0.5*grav*hl*hl*n_1) &
-        ! & + grav*hbar*(br-bl)*n_1
-        
-        ! fluxdiff(3) = (hr*vr*(ur*n_1 + vr*n_2)+0.5*grav*hr*hr*n_2)-(hl*vl*(ul*n_1 + vl*n_2)+0.5*grav*hl*hl*n_2) &
-        ! & + grav*hbar*(br-bl)*n_2
-    
-        ! # Wave speeds
+        ! Wave speeds
         s(1, i) = min(uhat - chat, ul - sqrt(grav * hl))
         s(3, i) = max(uhat + chat, ur + sqrt(grav * hr))
         s(2, i) = 0.5d0 * (s(1, i) + s(3, i))
-
-        ! s(1,i) = (uhat*n_1 + vhat*n_2) - chat
-        ! s(2,i) = (uhat*n_1 + vhat*n_2)
-        ! s(3,i) = (uhat*n_1 + vhat*n_2) + chat
         
-        !write(*,*) i,s(i,1),s(i,2),s(i,3)
-        
-        ! # Right eigenvectors (columns)
+        ! Right eigenvectors (columns)
+        ! could possibly use vhat instead of vl and vr
         R(1, 1) = 1.d0
-        R(2, 1) = s(1, i) * n_1 + vhat * n_2
-        R(3, 1) = s(1, i) * n_1 + vhat * n_2
-        ! R(2,1) = uhat - chat*n_1
-        ! R(3,1) = vhat - chat*n_2
+        R(normal_index, 1) = s(1, i)
+        R(transverse_index, 1) = vl
         
         R(1, 2) = 0.d0
-        R(2, 2) = -1.d0*n_2
-        R(3, 2) = n_1
+        R(normal_index, 2) = 0.0
+        R(transverse_index, 2) = 1.0
         
         R(1, 3) = 1.d0
-        R(2, 3) = s(3, i) * n_1 + vhat * n_2
-        R(3, 3) = s(3, i) * n_1 + vhat * n_2
-        ! R(2,3) = uhat + chat*n_1
-        ! R(3,3) = vhat + chat*n_2
+        R(normal_index, 3) = s(3, i)
+        R(transverse_index, 3) = vr
         
-        ! # Left eigenvectors (rows)
-        ! L(1,1) = ((uhat*n_1 + vhat*n_2) + chat)/(2.d0*chat)
-        ! L(1,2) = -1.d0*n_1/(2.d0*chat)
-        ! L(1,3) = -1.d0*n_2/(2.d0*chat)
-        
-        ! L(2,1) = uhat*n_2 - vhat*n_1 
-        ! L(2,2) = -1.d0*n_2
-        ! L(2,3) = n_1
-        
-        ! L(3,1) = (chat - (uhat*n_1 + vhat*n_2))/(2.d0*chat)
-        ! L(3,2) = n_1/(2.d0*chat)
-        ! L(3,3) = n_2/(2.d0*chat)
-        
-        
-        ! # Coefficients beta which multiply the right eigenvectors (see below)
-        ! do j=1,num_eqn
-        !     beta(j) = 0.d0
-        !     do k=1,num_eqn
-        !         beta(j) = beta(j) + L(j,k)*fluxdiff(k)
-        !     enddo
-        ! enddo
+        ! Wave strengths
         beta(1) = (s(3, i) * fluxdiff(1) - fluxdiff(2)) / (s(3, i) - s(1, i))
         beta(3) = (fluxdiff(2) - s(1, i) * fluxdiff(1)) / (s(3, i) - s(1, i))
-        beta(2) = hr * ur * vr - hl * ul * vl - beta(1) * vl - beta(3) * vr
+        beta(2) = fluxdiff(3) - beta(1) * vl - beta(3) * vr
 
-        ! # Flux waves
-        do k=1,num_eqn
+        ! f-waves
+        do k = 1, num_waves
             fwave(:, k, i) = beta(k) * R(:, k)
         enddo
     
-        ! # Fluctuations
+        ! Fluctuations - could probably rewrite this to be a masking operation
+        ! instead...
         do k=1, num_waves
             if (s(k, i) < 1.0e-14) then
                 amdq(:, i) = amdq(:, i) + fwave(:, k, i)
@@ -194,8 +141,12 @@ subroutine rpn2(ixy, maxm, num_eqn, num_waves, num_aux, num_ghost, &
                 apdq(:, i) = apdq(:, i) + 0.5d0 * fwave(:, k, i)
             endif
         enddo
-    
-    enddo
-    
-    return
+
+    enddo ! End of main loop
+
+    if (.not.all(amdq == 0.d0) .or. .not.all(apdq == 0.d0)) then
+        ! print *,amdq, apdq
+        stop "Uhoh"
+    end if
+
 end subroutine rpn2

--- a/src/rpn2_shallow_bathymetry_fwave.f90
+++ b/src/rpn2_shallow_bathymetry_fwave.f90
@@ -66,10 +66,6 @@ subroutine rpn2(ixy, maxm, num_eqn, num_waves, num_aux, num_ghost, &
         dry_state_l = merge(0.d0, 1.d0, qr(1, i - 1) < dry_tolerance)
         dry_state_r = merge(0.d0, 1.d0, ql(1, i) < dry_tolerance)
 
-        if (qr(1, i - 1) < dry_tolerance .or. ql(1, i) < dry_tolerance) then
-            stop "Cannot handle dry-states quite yet!"
-        end if
-
         ! Note that for the states below u is always the normal velocity and
         ! v is always the tangential velocity
 

--- a/src/rpt2_shallow_bathymetry_fwave.f90
+++ b/src/rpt2_shallow_bathymetry_fwave.f90
@@ -1,10 +1,119 @@
-! =====================================================
-subroutine rpt2(ixy,imp,maxm,num_eqn,num_waves,num_aux,num_ghost,num_cells,ql,qr,aux1,aux2,aux3,asdq,bmasdq,bpasdq)
-! =====================================================
-    implicit double precision (a-h,o-z)
+subroutine rpt2(ixy, imp, maxm, num_eqn, num_waves, num_aux, num_ghost,   &
+                num_cells, ql, qr, aux1, aux2, aux3, asdq, bmasdq, bpasdq)
+! Transverse solver for shallow water with bathymetry using an fwave solver
+! Note that this solver does NOT handle dry-states
+!
+! (h)_t + (h*u)_x = 0
+! (hu)_t + (h*u^2 + 1/2*grav*h^2)_x + (h*u*v)_y = -grav*h*(b)_x
+! (hv)_t + (h*u*v)_x + (h*v^2 + 1/2*grav*h^2)_y = -grav*h*(b)_y
+!
+! using the f-wave algorithm and Roe's approximate Riemann solver.  
+!
+! waves:     3
+! equations: 3
+!
+! Conserved quantities:
+!       1 depth
+!       2 x_momentum
+!       3 y_momentum
+!
+! Auxiliary fields:
+!       1 bathymetry
+!
+! The gravitational constant grav should be in the common block cparam.
+!
+! See http://www.clawpack.org/riemann.html for a detailed explanation
+! of the Riemann solver API.
 
-!     # Dummy transverse Riemann solver, for use in dimensionally-split algorithm.
+    implicit none
 
-    write(*,*) 'Error: Dummy transverse Riemann solver called!'
-    return
-    end subroutine rpt2
+    ! Input
+    integer, intent(in) :: ixy, imp, maxm, num_eqn, num_waves, num_aux
+    integer, intent(in) :: num_ghost, num_cells
+    real(kind=8), intent(in) :: ql(num_eqn, 1 - num_ghost:maxm + num_ghost)
+    real(kind=8), intent(in) :: qr(num_eqn, 1 - num_ghost:maxm + num_ghost)
+    real(kind=8), intent(in) :: aux1(num_aux, 1 - num_ghost:maxm + num_ghost)
+    real(kind=8), intent(in) :: aux2(num_aux, 1 - num_ghost:maxm + num_ghost)
+    real(kind=8), intent(in) :: aux3(num_aux, 1 - num_ghost:maxm + num_ghost)
+    real(kind=8), intent(in) :: asdq(num_eqn, 1 - num_ghost:maxm + num_ghost)
+
+    ! Output
+    real(kind=8), intent(out) :: bmasdq(num_eqn, 1 - num_ghost:maxm + num_ghost)
+    real(kind=8), intent(out) :: bpasdq(num_eqn, 1 - num_ghost:maxm + num_ghost)
+
+    ! Local
+    integer :: i, k, normal_index, transverse_index
+    real(kind=8) :: h_l, h_r, u_l, u_r, v_l, v_r, h_bar, h_root, u_hat, v_hat
+    real(kind=8) :: dry_state_l, dry_state_r, s(3), beta(3), R(3, 3)
+
+    ! Parameters
+    real(kind=8) :: grav, dry_tolerance, sea_level
+    common /cparam/ grav, dry_tolerance, sea_level
+
+    ! Deterimine direction of solve
+    if (ixy == 1) then
+        normal_index = 2
+        transverse_index = 3
+    else
+        normal_index = 3
+        transverse_index = 2
+    end if
+
+    ! Primary loop over cell edges
+    do i = 2 - num_ghost, num_cells + num_ghost
+        
+        ! Check for dry states - need merge here to convert to float
+        dry_state_l = merge(0.d0, 1.d0, qr(1, i - 1) < dry_tolerance)
+        dry_state_r = merge(0.d0, 1.d0, ql(1, i) < dry_tolerance)
+
+        ! Extract state variables
+        h_l = qr(1, i - 1) * dry_state_l
+        u_l = qr(normal_index, i - 1) / qr(1, i - 1) * dry_state_l
+        v_l = qr(transverse_index, i - 1) / qr(1, i - 1) * dry_state_l
+
+        h_r = ql(1, i) * dry_state_r
+        u_r = ql(normal_index, i) / ql(1, i) * dry_state_r
+        v_r = ql(transverse_index, i) / ql(1, i) * dry_state_r
+
+        ! Determine speeds for the Jacobian
+        h_bar = 0.5d0 * (h_r + h_l)
+        h_root = sqrt(h_r) + sqrt(h_l)
+        v_hat = (v_r * sqrt(h_r)) / h_root + (v_l * sqrt(h_l)) / h_root
+        u_hat = (u_r * sqrt(h_r)) / h_root + (u_l * sqrt(h_l)) / h_root
+
+        s(1) = min(v_hat - sqrt(grav * h_bar), v_l - sqrt(grav * h_l))
+        s(3) = max(v_hat + sqrt(grav * h_bar), v_r + sqrt(grav * h_r))
+        s(2) = 0.5d0 * (s(1) + s(2))
+
+        ! Determine asdq decompisition
+        beta(1) = s(3) * asdq(1, i) / (s(3) - s(1))                 &
+                                - asdq(transverse_index, i) / (s(3) - s(1))
+        beta(2) = -s(2) * asdq(1, i) + asdq(normal_index, i)
+        beta(3) = asdq(transverse_index, i) / (s(3) - s(1))         &
+                                - (s(1) * asdq(1, i) / (s(3) - s(1)))
+
+        ! Eigenvectors
+        R(1, :) = [1.d0, 0.d0, 1.d0]
+        R(2, :) = [s(2), 1.d0, s(2)]
+        R(3, :) = [s(1), 0.d0, s(3)]
+
+        ! Compute fluctuations
+        do k = 1, num_waves
+            if (s(k) < 0.d0) then
+                bmasdq(1, i) = bmasdq(1, i) + s(k) * beta(k) * R(1, k)
+                bmasdq(normal_index, i) = bmasdq(normal_index, i)              &
+                                                + s(k) * beta(k) * R(2, k)
+                bmasdq(transverse_index, i) = bmasdq(transverse_index, i)      &
+                                                + s(k) * beta(k) * R(3, k)
+            else
+                bpasdq(1, i) = bpasdq(1, i) + s(k) * beta(k) * R(1, k)
+                bpasdq(normal_index, i) = bpasdq(normal_index, i)              &
+                                                + s(k) * beta(k) * R(2, k)
+                bpasdq(transverse_index, i) = bpasdq(transverse_index, i)      &
+                                                + s(k) * beta(k) * R(3, k)
+            end if
+        end do
+
+    end do  ! End of primary loop
+
+end subroutine rpt2


### PR DESCRIPTION
This is not quite working still but at least works with out bathymetry.  Currently the flux difference does not seem to cancel correctly.  In other words, in a steady state configuration the flux difference and the source terms should subtract to zero:
```
delta_phi = 0.5 * g * hR**2 - 0.5 * g * hL**2 + hR * uR**2 - hL * uL**2
delta_s = 0.5 * g * (hR + hL) * (bR - bL)
delta_phi - delta_s = 0.5 * g * hR**2 - 0.5 * g * hL**2 + hR * uR**2 - hL * uL**2 - 0.5 * g * (hR + hL) * (bR - bL)
delta_phi - delta_s = 0.5 * g * (hR**2 - hL**2) - 0.5 * g * (hR + hL) * (bR - bL)
delta_phi - delta_s = 0.5 * g * (hR - hL) * (hR + hL) - 0.5 * g * (hR + hL) * (bR - bL)
```
Since the sea-surface would be zero then `(hR - hL) == (bR - bL)` and the expression equates to zero.  Currently this is not the case.
